### PR TITLE
fix: ignore zero rates in best value calculation

### DIFF
--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -59,6 +59,28 @@ describe("findBestRates", () => {
       bestSellEUR: "6.40",
     });
   });
+
+  it("ignores zero rates when determining best values", () => {
+    const result = findBestRates([
+      {
+        name: "Zero Bank",
+        logo: "",
+        link: "",
+        rates: [
+          { currency: "USD", buy: "0", sell: "0" },
+          { currency: "EUR", buy: "0", sell: "0" },
+        ],
+      },
+      ...sampleRates,
+    ]);
+
+    expect(result).toEqual({
+      bestBuyUSD: "5.50",
+      bestSellUSD: "5.80",
+      bestBuyEUR: "5.60",
+      bestSellEUR: "6.40",
+    });
+  });
 });
 
 describe("getRates", () => {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -74,19 +74,23 @@ export function findBestRates(allRates: BankRates[]): {
 
   allRates.forEach(({ rates }) => {
     rates.forEach((rate) => {
+      const buy = Number.parseFloat(rate.buy);
+      const sell = Number.parseFloat(rate.sell);
+
       if (rate.currency === "USD") {
-        if (Number.parseFloat(rate.buy) > Number.parseFloat(bestBuyUSD))
-          bestBuyUSD = rate.buy;
-        if (Number.parseFloat(rate.sell) < Number.parseFloat(bestSellUSD))
+        if (buy > 0 && buy > Number.parseFloat(bestBuyUSD)) bestBuyUSD = rate.buy;
+        if (sell > 0 && sell < Number.parseFloat(bestSellUSD))
           bestSellUSD = rate.sell;
       } else if (rate.currency === "EUR") {
-        if (Number.parseFloat(rate.buy) > Number.parseFloat(bestBuyEUR))
-          bestBuyEUR = rate.buy;
-        if (Number.parseFloat(rate.sell) < Number.parseFloat(bestSellEUR))
+        if (buy > 0 && buy > Number.parseFloat(bestBuyEUR)) bestBuyEUR = rate.buy;
+        if (sell > 0 && sell < Number.parseFloat(bestSellEUR))
           bestSellEUR = rate.sell;
       }
     });
   });
+
+  if (bestSellUSD === "999999") bestSellUSD = "0";
+  if (bestSellEUR === "999999") bestSellEUR = "0";
 
   return { bestBuyUSD, bestSellUSD, bestBuyEUR, bestSellEUR };
 }


### PR DESCRIPTION
## Summary
- ignore zero buy/sell rates when calculating best rates
- add test ensuring zero rates are skipped

## Testing
- `pnpm lint`
- `pnpm test --run` *(fails: Error [ERR_REQUIRE_ESM]: require() of ES Module vite/dist/node/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bed15ac844832caba47613566eec78